### PR TITLE
include sharing to a personal wordpress blog

### DIFF
--- a/_posts/2013-11-28-sharing-read-it-later-services.md
+++ b/_posts/2013-11-28-sharing-read-it-later-services.md
@@ -79,4 +79,5 @@ List of URLs
 | Twitter for Mac/iOS   | `twitter://post?message=${title}%20${url}`                                         |
 | Twitterrific          | `twitterrific:///post?message=${title}%20${url}`                                   |
 | Weibo                 | `http://service.weibo.com/share/share.php?url=${url}&title=${title}`               |
+| WordPress             | `https://your-wordpress-site.tld/wp-admin/press-this.php?u=${url}`                 |
 | Fastmail              | `https://www.fastmail.fm/action/compose/?to=&subject=${title}&body=${url}`         |


### PR DESCRIPTION
I've used this for a while now to share from feedbin to my wordpress blog and it works well. Huge fan of my feedbin service. 